### PR TITLE
Enable importing of vyos_config resources

### DIFF
--- a/docs/resources/config.md
+++ b/docs/resources/config.md
@@ -28,8 +28,14 @@ resource "vyos_config" "hostname" {
 - **key** (String) Config path separated by spaces.
 - **value** (String) Config value.
 
-### Optional
+### Read-Only
 
-- **id** (String) The ID of this resource.
+- **id** (String) The resource ID, same as the `key`
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+terraform import vyos_config.hostname "system host-name"
+```

--- a/docs/resources/config_block.md
+++ b/docs/resources/config_block.md
@@ -44,7 +44,7 @@ resource "vyos_config_block" "allow_sith_supremacy_jedi" {
 
 ### Read-Only
 
-- **id** (String) The resource ID.
+- **id** (String) The resource ID, same as the `path`
 
 ## Import
 

--- a/examples/resources/vyos_config/import.sh
+++ b/examples/resources/vyos_config/import.sh
@@ -1,0 +1,1 @@
+terraform import vyos_config.hostname "system host-name"

--- a/vyos/resource_config_block.go
+++ b/vyos/resource_config_block.go
@@ -23,7 +23,7 @@ func resourceConfigBlock() *schema.Resource {
 		},
 		Schema: map[string]*schema.Schema{
 			"id": {
-				Description: "The resource ID.",
+				Description: "The resource ID, same as the `path`",
 				Type:        schema.TypeString,
 				Computed:    true,
 			},


### PR DESCRIPTION
This PR mostly focuses on giving the vyos_config resource an easy implementation of the import functionality.
A change to the ID format is required to achieve this without a custom import function. There is also a tiny improvement to the docs that clarify what the ID is in case someone needs it to understand how to import a resource.

The read function will now detect the old v0.x.x provider version ID format and convert it to the new format automatically on apply.

As mentioned in [the versioning doc](https://www.terraform.io/docs/extend/best-practices/versioning.html#example-major-number-increments) this change of the resource ID format should trigger a major version release, even though steps have been taken to make manual steps redundant.