### PR TITLE
fix make test

### DIFF
--- a/vyos/resource_config.go
+++ b/vyos/resource_config.go
@@ -53,7 +53,7 @@ func resourceConfigCreate(ctx context.Context, d *schema.ResourceData, m interfa
 	}
 	// Dont care about sub config blocks
 	if val != nil {
-		return diag.Errorf("Configuration '%s' already exists with value '%s' set, try a resource import instead.", key, val)
+		return diag.Errorf("Configuration '%s' already exists with value '%s' set, try a resource import instead.", key, *val)
 	}
 
 	err = c.Config.Set(key, value)


### PR DESCRIPTION
`make test` was failing with 

```
# make test
go test -i $(go list ./... | grep -v 'vendor') || exit 1                                                   
go: -i flag is deprecated
echo $(go list ./... | grep -v 'vendor') | xargs -t -n4 go test  -timeout=30s -parallel=4                    
go test '-timeout=30s' '-parallel=4' github.com/foltik/terraform-provider-vyos github.com/foltik/terraform-provider-vyos/vyos 
# github.com/foltik/terraform-provider-vyos/vyos
vyos/resource_config.go:56:10: github.com/hashicorp/terraform-plugin-sdk/v2/diag.Errorf format %s has arg val of wrong type *string
?       github.com/foltik/terraform-provider-vyos       [no test files]
make: *** [Makefile:37: test] Error 123
```