### PR TITLE
change default timeout

### DIFF
--- a/vyos/data_source_config.go
+++ b/vyos/data_source_config.go
@@ -23,8 +23,8 @@ func dataSourceConfig() *schema.Resource {
 			},
 		},
         Timeouts: &schema.ResourceTimeout{
-			Read:    schema.DefaultTimeout(10 * time.Second),
-			Default: schema.DefaultTimeout(10 * time.Second),
+			Read:    schema.DefaultTimeout(10 * time.Minute),
+			Default: schema.DefaultTimeout(10 * time.Minute),
 		},
 	}
 }

--- a/vyos/resource_config.go
+++ b/vyos/resource_config.go
@@ -37,11 +37,11 @@ func resourceConfig() *schema.Resource {
 			},
 		},
         Timeouts: &schema.ResourceTimeout{
-			Create:  schema.DefaultTimeout(10 * time.Second),
-			Read:    schema.DefaultTimeout(10 * time.Second),
-			Update:  schema.DefaultTimeout(10 * time.Second),
-			Delete:  schema.DefaultTimeout(10 * time.Second),
-			Default: schema.DefaultTimeout(10 * time.Second),
+			Create:  schema.DefaultTimeout(10 * time.Minute),
+			Read:    schema.DefaultTimeout(10 * time.Minute),
+			Update:  schema.DefaultTimeout(10 * time.Minute),
+			Delete:  schema.DefaultTimeout(10 * time.Minute),
+			Default: schema.DefaultTimeout(10 * time.Minute),
 		},
 	}
 }

--- a/vyos/resource_config_block.go
+++ b/vyos/resource_config_block.go
@@ -44,11 +44,11 @@ func resourceConfigBlock() *schema.Resource {
 			},
 		},
         Timeouts: &schema.ResourceTimeout{
-			Create:  schema.DefaultTimeout(10 * time.Second),
-			Read:    schema.DefaultTimeout(10 * time.Second),
-			Update:  schema.DefaultTimeout(10 * time.Second),
-			Delete:  schema.DefaultTimeout(10 * time.Second),
-			Default: schema.DefaultTimeout(10 * time.Second),
+			Create:  schema.DefaultTimeout(10 * time.Minute),
+			Read:    schema.DefaultTimeout(10 * time.Minute),
+			Update:  schema.DefaultTimeout(10 * time.Minute),
+			Delete:  schema.DefaultTimeout(10 * time.Minute),
+			Default: schema.DefaultTimeout(10 * time.Minute),
 		},
 	}
 }

--- a/vyos/resource_config_block_tree.go
+++ b/vyos/resource_config_block_tree.go
@@ -44,11 +44,11 @@ func resourceConfigBlockTree() *schema.Resource {
 			},
 		},
         Timeouts: &schema.ResourceTimeout{
-			Create:  schema.DefaultTimeout(10 * time.Second),
-			Read:    schema.DefaultTimeout(10 * time.Second),
-			Update:  schema.DefaultTimeout(10 * time.Second),
-			Delete:  schema.DefaultTimeout(10 * time.Second),
-			Default: schema.DefaultTimeout(10 * time.Second),
+			Create:  schema.DefaultTimeout(10 * time.Minute),
+			Read:    schema.DefaultTimeout(10 * time.Minute),
+			Update:  schema.DefaultTimeout(10 * time.Minute),
+			Delete:  schema.DefaultTimeout(10 * time.Minute),
+			Default: schema.DefaultTimeout(10 * time.Minute),
 		},
 	}
 }

--- a/vyos/resource_static_host_mapping.go
+++ b/vyos/resource_static_host_mapping.go
@@ -30,11 +30,11 @@ func resourceStaticHostMapping() *schema.Resource {
 			},
 		},
         Timeouts: &schema.ResourceTimeout{
-			Create:  schema.DefaultTimeout(10 * time.Second),
-			Read:    schema.DefaultTimeout(10 * time.Second),
-			Update:  schema.DefaultTimeout(10 * time.Second),
-			Delete:  schema.DefaultTimeout(10 * time.Second),
-			Default: schema.DefaultTimeout(10 * time.Second),
+			Create:  schema.DefaultTimeout(10 * time.Minute),
+			Read:    schema.DefaultTimeout(10 * time.Minute),
+			Update:  schema.DefaultTimeout(10 * time.Minute),
+			Delete:  schema.DefaultTimeout(10 * time.Minute),
+			Default: schema.DefaultTimeout(10 * time.Minute),
 		},
 	}
 }


### PR DESCRIPTION
With around 20 rules the 10 seconds timeout always fails on refresh.

Ideally the refresh could be speed up without locking but for now this avoids the error.